### PR TITLE
Use HEAD requests instead of GET

### DIFF
--- a/src/validation/mod.rs
+++ b/src/validation/mod.rs
@@ -8,7 +8,9 @@ mod web;
 pub use cache::{Cache, CacheEntry};
 pub use context::{BasicContext, Context};
 pub use filesystem::{check_filesystem, resolve_link, Options};
-pub use web::{check_web, get};
+pub use web::{check_web, head};
+#[allow(deprecated)]
+pub use web::get;
 
 use crate::{Category, Link};
 use futures::{Future, StreamExt};

--- a/src/validation/web.rs
+++ b/src/validation/web.rs
@@ -3,14 +3,27 @@ use http::HeaderMap;
 use reqwest::{Client, Url};
 use std::time::SystemTime;
 
-/// Send a GET request to a particular endpoint.
+#[deprecated]
+/// Send a HEAD request to a particular endpoint.
+///
+/// This function is deprecated in favor of [`head`].
 pub async fn get(
     client: &Client,
     url: Url,
     extra_headers: HeaderMap,
 ) -> Result<(), reqwest::Error> {
+    head(client, url, extra_headers).await?;
+    Ok(())
+}
+
+/// Send a HEAD request to a particular endpoint.
+pub async fn head(
+    client: &Client,
+    url: Url,
+    extra_headers: HeaderMap,
+) -> Result<(), reqwest::Error> {
     client
-        .get(url)
+        .head(url)
         .headers(extra_headers)
         .send()
         .await?
@@ -32,7 +45,7 @@ where
     }
 
     let result =
-        get(ctx.client(), url.clone(), ctx.url_specific_headers(&url)).await;
+        head(ctx.client(), url.clone(), ctx.url_specific_headers(&url)).await;
 
     if let Some(fragment) = url.fragment() {
         // TODO: check the fragment


### PR DESCRIPTION
This puts less load on the remote server, and may possibly have a higher
rate limit than GET.

From https://rust-lang.zulipchat.com/#narrow/stream/196385-t-compiler.2Fwg-rustc-dev-guide/topic/failing.20CI.20notifications/near/204958576