### PR TITLE
Only publish API docs from master branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,7 @@ jobs:
 
   api-docs:
     name: Publish API Docs to GitHub Pages
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This avoids spurious CI failures for PRs that are not from a branch on
the repository. It also avoids changing the docs for PRs that have not
yet been merged.

Fixes the issue raised in https://github.com/Michael-F-Bryan/linkcheck/pull/1#issuecomment-663916205